### PR TITLE
Added custom MIN/MAX and compile #DEFINE options for SERIALCOMMS and MINMAX

### DIFF
--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -39,6 +39,8 @@ byte recvInitPacket(byte array[]);
 uint16_t getMax(uint16_t a, uint16_t b);
 uint16_t getMin(uint16_t a, uint16_t b);
 void toggleIdleParameter();
+void toggleMinHeight();
+void toggleMaxHeight();
 
 int loadMemory(uint8_t memorySlot);
 void saveMemory(uint8_t memorySlot, int value);


### PR DESCRIPTION
Added support for custom min/max and a compile option to enable/disable the feature. #23 
Enable/disable sounds should probably be modified.

Added a compile option to enable/disable the serial communication feature. #12

Once more space is available (via optimization or a new AVR) code should be added to reload the MAX/MIN when saving using the serial port.