### PR TITLE
Fixed min/max and serial

### DIFF
--- a/Code/platformio.ini
+++ b/Code/platformio.ini
@@ -17,7 +17,7 @@ framework = arduino
 board_fuses.lfuse = 0xE2
 board_fuses.efuse = 0xFE
 board_fuses.hfuse = 0xD6
-upload_protocl = custom
+upload_protocol = custom
 upload_command = 
     avrdude -B 0.5 -c stk500v2 -p attiny841 -V -Uflash:w:$SOURCE:i -P COM6
 
@@ -31,10 +31,4 @@ board_fuses.hfuse = 0xD6
 upload_protocol = custom
 upload_port = COM3
 upload_speed = 115200
-upload_flags =
-    -C $PROJECT_PACKAGES_DIR/tool-avrdude/avrdude.conf
-    -p $BOARD_MCU
-    -P $UPLOAD_PORT
-    -b $UPLOAD_SPEED
-    -c buspirate
-upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
+upload_command = avrdude -b $UPLOAD_SPEED -c buspirate -p $BOARD -V -U flash:w:$SOURCE:i -P $UPLOAD_PORT

--- a/Code/platformio.ini
+++ b/Code/platformio.ini
@@ -20,3 +20,21 @@ board_fuses.hfuse = 0xD6
 upload_protocl = custom
 upload_command = 
     avrdude -B 0.5 -c stk500v2 -p attiny841 -V -Uflash:w:$SOURCE:i -P COM6
+
+[env:attiny841_BP_windows]
+platform = atmelavr
+board = attiny841
+framework = arduino
+board_fuses.lfuse = 0xE2
+board_fuses.efuse = 0xFE
+board_fuses.hfuse = 0xD6
+upload_protocol = custom
+upload_port = COM3
+upload_speed = 115200
+upload_flags =
+    -C $PROJECT_PACKAGES_DIR/tool-avrdude/avrdude.conf
+    -p $BOARD_MCU
+    -P $UPLOAD_PORT
+    -b $UPLOAD_SPEED
+    -c buspirate
+upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -3,7 +3,7 @@
 #include "megadesk.h"
 
 #define SERIALCOMMS
-//#define MINMAX
+#define MINMAX
 
 #define HYSTERESIS 137
 #define PIN_UP 10
@@ -369,6 +369,7 @@ void loop()
   linBurst();
 
 #if defined SERIALCOMMS
+#if !defined MINMAX
   if (memoryMoving == false && oldHeight != currentHeight){
     if (oldHeight < currentHeight){
       writeSerial(command_increase, currentHeight-oldHeight, pushCount);
@@ -377,6 +378,7 @@ void loop()
       writeSerial(command_decrease, oldHeight-currentHeight, pushCount);
     }
   }
+#endif
 #endif
 
   readButtons();

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -329,14 +329,26 @@ void parseData()
   }
   else if (command == command_write)
   {
+    // if position not set, then set to currentHeight
     if (position == 0)
     {
-      saveMemory(push_addr, currentHeight);
+      position = currentHeight;
     }
-    else
+
+    // save position to memory location
+    saveMemory(push_addr, position);
+
+#if defined MINMAX
+    //if changing memory location for min/max height, update corect variable
+    if (push_addr == 20)
     {
-      saveMemory(push_addr, position);
+      minHeight = position;
     }
+    else if (push_addr == 22)
+    {
+      maxHeight = position;
+    }
+#endif
   }
   else if (command == command_load)
   {
@@ -345,7 +357,7 @@ void parseData()
   }
   else if (command == command_read)
   {
-    writeSerial(command_read, BitShiftCombine(EEPROM.read(2 * push_addr), EEPROM.read((2 * push_addr) + 1)), push_addr);
+    writeSerial(command_read, BitShiftCombine(EEPROM.read((2 * push_addr) + 1), EEPROM.read(2 * push_addr)), push_addr);
   }
 }
 #endif

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -454,6 +454,9 @@ void loop()
     targetHeight = currentHeight - HYSTERESIS - 1;
   }
   else if (!memoryMoving){
+    if (oldHeight != currentHeight){
+      writeSerial(command_absolute, currentHeight);
+    }
     targetHeight = currentHeight;
   }
 

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -56,10 +56,8 @@ int targetHeight = -1;
 unsigned long end, d;
 unsigned long t = 0;
 
-#if defined MINMAX
 int maxHeight = DANGER_MAX_HEIGHT;
 int minHeight = DANGER_MIN_HEIGHT;
-#endif
 
 // Set default to 96 but this might be change from EEPROM
 byte LIN_MOTOR_IDLE = 96;
@@ -439,17 +437,9 @@ void loop()
   else if (!memoryMoving)
     targetHeight = currentHeight;
 
-#if defined MINMAX
   if (targetHeight > currentHeight && abs(targetHeight - currentHeight) > HYSTERESIS && currentHeight < maxHeight)
-#else
-  if (targetHeight > currentHeight && abs(targetHeight - currentHeight) > HYSTERESIS && currentHeight < DANGER_MAX_HEIGHT)
-#endif
     up(true);
-#if defined MINMAX
   else if (targetHeight < currentHeight && abs(targetHeight - currentHeight) > HYSTERESIS && currentHeight > minHeight)
-#else
-  else if (targetHeight < currentHeight && abs(targetHeight - currentHeight) > HYSTERESIS && currentHeight > DANGER_MIN_HEIGHT)
-#endif
     down(true);
   else
   {
@@ -567,21 +557,13 @@ void linBurst()
     }
     break;
   case State::UP:
-#if defined MINMAX
     if (user_cmd != Command::UP || currentHeight >= maxHeight)
-#else
-    if (user_cmd != Command::UP || currentHeight >= DANGER_MAX_HEIGHT)
-#endif
     {
       state = State::STOPPING1;
     }
     break;
   case State::DOWN:
-#if defined MINMAX
     if (user_cmd != Command::DOWN || currentHeight <= minHeight)
-#else
-    if (user_cmd != Command::DOWN || currentHeight <= DANGER_MIN_HEIGHT)
-#endif
     {
       state = State::STOPPING1;
     }

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -369,7 +369,7 @@ void loop()
   linBurst();
 
 #if defined SERIALCOMMS
-#if !defined MINMAX
+#if !defined MINMAX || (FLASHEND-FLASHSTART+1 > 8192)
   if (memoryMoving == false && oldHeight != currentHeight){
     if (oldHeight < currentHeight){
       writeSerial(command_increase, currentHeight-oldHeight, pushCount);

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -423,7 +423,7 @@ void loop()
     memoryMoving = false;
     targetHeight = currentHeight + HYSTERESIS + 1;
 #if defined SERIALCOMMS
-    writeSerial(command_increase, HYSTERESIS + 1);
+    writeSerial(command_absolute, targetHeight);
 #endif
   }
   else if (goDown)
@@ -431,7 +431,7 @@ void loop()
     memoryMoving = false;
     targetHeight = currentHeight - HYSTERESIS - 1;
 #if defined SERIALCOMMS
-    writeSerial(command_decrease, HYSTERESIS - 1);
+    writeSerial(command_absolute, targetHeight);
 #endif
   }
   else if (!memoryMoving)
@@ -872,8 +872,6 @@ void toggleMinHeight()
   
   beep(1, 2093);
   delay(50);
-  beep(1, 2349);
-  delay(50);
   beep(1, minHeight);
 
   EEPROM.write(40, minHeight);
@@ -893,8 +891,6 @@ void toggleMaxHeight()
   }
 
   beep(1, 2093);
-  delay(50);
-  beep(1, 2349);
   delay(50);
   beep(1, maxHeight);
 


### PR DESCRIPTION
I have fixed the Min/Max to work on boot.  The previous code would set the minHeight and maxHeight to 0 on boot.

The change to serial, when manually moving, now prints the difference between the current height and previous height every loop.  Then when movement is done prints the current height.


Also fixed the stk500v2 upload protocol and added PlatformIO directives for Bus Pirate