### PR TITLE
replaced toggleIdleParameter() 

### DIFF
--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -32,7 +32,6 @@ uint8_t recvInitPacket(uint8_t array[]);
 
 uint16_t getMax(uint16_t a, uint16_t b);
 uint16_t getMin(uint16_t a, uint16_t b);
-void toggleIdleParameter();
 
 int loadMemory(int memorySlot);
 void saveMemory(int memorySlot, int value);


### PR DESCRIPTION
I've removed the _toggleIdleParameter_ function and added a simple comparison with all known IDLE states. This (should) avoid that you have to manually toggle the state value.
