### PR TITLE
Reduce image size.

### DIFF
--- a/Code/include/lin.h
+++ b/Code/include/lin.h
@@ -57,8 +57,7 @@ public:
   void begin(int speed);
 
   // Send a message right now, ignoring the schedule table.
-  void send(uint8_t addr, const uint8_t* message,uint8_t nBytes,uint8_t proto=2);
-  void send(uint8_t addr, const uint8_t* message, uint8_t nBytes, uint8_t proto, uint8_t cksum);
+  void send(uint8_t addr, const uint8_t* message, uint8_t nBytes, uint8_t proto=2, int16_t cksum=-1);
 
   // Receive a message right now, returns 0xff if good checksum, # bytes received (including checksum) if checksum is bad.
   uint8_t recv(uint8_t addr, uint8_t* message, uint8_t nBytes,uint8_t proto=2);

--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -21,13 +21,13 @@ enum class Command : byte
   DOWN,
 };
 
-void beep(byte count, int freq);
+void beep(byte count, int16_t freq);
 void initAndReadEEPROM(bool force);
 void linInit();
 void linBurst();
 
 void recvWithStartEndMarkers();
-void writeSerial(char operation, int position, uint8_t push_addr = 0);
+void writeSerial(char operation, uint16_t position, uint8_t push_addr = 0);
 int BitShiftCombine(uint8_t x_high, uint8_t x_low);
 void parseData();
 
@@ -36,13 +36,10 @@ void delay_until(unsigned long microSeconds);
 void sendInitPacket(byte a1 = 255, byte a2 = 255, byte a3 = 255, byte a4 = 255);
 byte recvInitPacket(byte array[]);
 
-uint16_t getMax(uint16_t a, uint16_t b);
-uint16_t getMin(uint16_t a, uint16_t b);
-
 #ifdef MINMAX
 void toggleMinHeight();
 void toggleMaxHeight();
 #endif
 
-int loadMemory(uint8_t memorySlot);
-void saveMemory(uint8_t memorySlot, int value);
+uint16_t loadMemory(uint8_t memorySlot);
+void saveMemory(uint8_t memorySlot, uint16_t value);

--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -41,5 +41,8 @@ void toggleMinHeight();
 void toggleMaxHeight();
 #endif
 
+uint16_t eeprom_get16( int idx );
+void eeprom_put16( int idx, uint16_t val );
+
 uint16_t loadMemory(uint8_t memorySlot);
 void saveMemory(uint8_t memorySlot, uint16_t value);

--- a/Code/src/lin.cpp
+++ b/Code/src/lin.cpp
@@ -86,22 +86,11 @@ uint8_t Lin::addrParity(uint8_t addr)
   return (p0 | (p1<<1))<<6;
 }
 
-/* Send a message across the Lin bus */
-void Lin::send(uint8_t addr, const uint8_t* message, uint8_t nBytes,uint8_t proto)
-{
-  uint8_t addrbyte = (addr&0x3f) | addrParity(addr);
-  uint8_t cksum = dataChecksum(message,nBytes,(proto==1) ? 0:addrbyte);
-  serialBreak();       // Generate the low signal that exceeds 1 char.
-  serial.write(0x55);  // Sync byte
-  serial.write(addrbyte);  // ID byte
-  serial.write(message,nBytes);  // data bytes
-  serial.write(cksum);  // checksum
-  serial.flush();
-}
-
-void Lin::send(uint8_t addr, const uint8_t* message, uint8_t nBytes, uint8_t proto, uint8_t cksum)
+void Lin::send(uint8_t addr, const uint8_t* message, uint8_t nBytes, uint8_t proto, int16_t cksum)
 {
   uint8_t addrbyte = (addr & 0x3f) | addrParity(addr);
+  if (cksum == -1)
+    cksum = dataChecksum(message,nBytes,(proto==1) ? 0:addrbyte);
   serialBreak();       // Generate the low signal that exceeds 1 char.
   serial.write(0x55);  // Sync byte
   serial.write(addrbyte);  // ID byte

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -265,10 +265,6 @@ void recvData()
       {
         receivedBytes[ndx] = rc;
         ndx++;
-        if (ndx >= numBytes)
-        {
-          ndx = numBytes - 1;
-        }
       }
       else
       {

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Unfortunately the beeps aren't captured well in the video unless you turn up the
 (Updated Feb 20, 2021)
 There are now 3 different status codes, which means 3 possible configurations. The unit ships by default with mode 1 activated. Changing to an incorrect mode will not harm the desk. The unit will beep and be responsive, but the motors will not engage.
 
+(older software)
 Pressing the UP button 16 times will play a 2-note "beep-boop" tone. 
 - Single - variant mode 1
 - Double - variant mode 2
@@ -35,7 +36,7 @@ Any unit shipped after Feb 20, 2021 from the Tindie store will have the 3rd mode
 To set assign a memory slot you press the up button two or more times. On the final button press you hold until you hear a tone that indicates what slot you have assigned (2 beeps, 3 beeps, etc).
 
 ## Recalling
-To recall a memory slot you push the up button the number of times for that memory slot (2 for first slot, 3 for second slot, etc). If you try to recall a memory slot that has not been saved you will here a "beep-boop" chime indicating that no height information could be recalled.
+To recall a memory slot you push the up button the number of times for that memory slot (2 for first slot, 3 for second slot, etc). If you try to recall a memory slot that has not been saved you will hear an "error" chime indicating that no height information could be recalled.
 
 
 # Troubleshooting


### PR DESCRIPTION
Image stats:
Regular:
RAM:   [===       ]  25.6% (used 131 bytes from 512 bytes)
Flash: [=======   ]  74.8% (used 6126 bytes from 8192 bytes)

with SERIALCOMMS & MINMAX:
RAM:   [====      ]  39.6% (used 203 bytes from 512 bytes)
Flash: [========= ]  86.1% (used 7056 bytes from 8192 bytes)

It's now possible to run the platformio "project Inspection" tool with both serial and minmax on.
There should be space now for calibration if we ever capture the message sequence...

There's a lot of changes here, I tried to verify all functionality but can't send commands over serial just yet.