### PR TITLE
Use either/both buttons to store and recall memory

### DIFF
--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -29,7 +29,7 @@ enum class Button : byte
   BOTH,
 };
 
-void beep(byte count, int16_t freq);
+void beep(uint16_t freq, byte count=1);
 void initAndReadEEPROM(bool force);
 void linInit();
 void linBurst();

--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -21,6 +21,14 @@ enum class Command : byte
   DOWN,
 };
 
+enum class Button : byte
+{
+  NONE,
+  UP,
+  DOWN,
+  BOTH,
+};
+
 void beep(byte count, int16_t freq);
 void initAndReadEEPROM(bool force);
 void linInit();
@@ -31,7 +39,7 @@ void writeSerial(char operation, uint16_t position, uint8_t push_addr = 0);
 int BitShiftCombine(uint8_t x_high, uint8_t x_low);
 void parseData();
 
-void delay_until(unsigned long microSeconds);
+void delayUntil(unsigned long microSeconds);
 
 void sendInitPacket(byte a1 = 255, byte a2 = 255, byte a3 = 255, byte a4 = 255);
 byte recvInitPacket(byte array[]);
@@ -41,8 +49,8 @@ void toggleMinHeight();
 void toggleMaxHeight();
 #endif
 
-uint16_t eeprom_get16( int idx );
-void eeprom_put16( int idx, uint16_t val );
+uint16_t eepromGet16( int idx );
+void eepromPut16( int idx, uint16_t val );
 
 uint16_t loadMemory(uint8_t memorySlot);
 void saveMemory(uint8_t memorySlot, uint16_t value);

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -68,8 +68,9 @@
 #define DANGER_MAX_HEIGHT 6777 - HYSTERESIS - SAFETY
 #define DANGER_MIN_HEIGHT 162 + HYSTERESIS + SAFETY
 
-// constants related to presses
-#define RIGHT_SLOT_START 10
+// constants related to presses/eeprom slots
+// (on attiny841: 512byte eeprom means max 255 slots)
+#define RIGHT_SLOT_START 32
 #define MIN_HEIGHT_SLOT 20
 #define MAX_HEIGHT_SLOT 22
 
@@ -246,6 +247,9 @@ void readButtons()
 #endif
   } else {
     buttons = NONE;
+#ifndef BOTH_BUTTONS
+    goDown = false;
+#endif
   }
 
   // If already moving and any button is pressed - stop

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -448,7 +448,6 @@ void loop()
   linBurst();
 
 #ifdef SERIALCOMMS
-#if !defined MINMAX || (FLASHEND-FLASHSTART+1 > 8192)
   if (memoryMoving == false && oldHeight != currentHeight){
     if (oldHeight < currentHeight){
       writeSerial(command_increase, currentHeight-oldHeight, pushCount);
@@ -457,7 +456,6 @@ void loop()
       writeSerial(command_decrease, oldHeight-currentHeight, pushCount);
     }
   }
-#endif
 #endif
 
   readButtons();

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -1,8 +1,8 @@
 // Uncomment this define if you want serial
-#define SERIALCOMMS
+//#define SERIALCOMMS
 
 // Uncomment this if you want to override minimum/maximum heights
-#define MINMAX
+//#define MINMAX
 
 // Uncomment to store/recall memories from both buttons
 #define BOTHBUTTONS
@@ -72,7 +72,7 @@
 // (on attiny841: 512byte eeprom means max 255 slots)
 #define MIN_HEIGHT_SLOT 20
 #define MAX_HEIGHT_SLOT 22
-#define RIGHT_SLOT_START 32
+#define RIGHT_SLOT_START 32 // 0x20 in hex
 
 // EEPROM magic signature to detect if eeprom is valid
 #define EEPROM_LOCATION_SIG 0

--- a/DIY.md
+++ b/DIY.md
@@ -8,7 +8,11 @@ If you want to create your own cable, the connector is AMP VAL-U-LOK by TE Conne
 
 Don't forget to set fuses on your board for the appropriate oscillator!
 
-ATTiny 841 - 8Mhz internal `avrdude -c usbtiny -p t841 -U lfuse:w:0xe2:m`
+ATTiny 841 - 8Mhz internal
+`avrdude -c usbtiny -p t841 -U lfuse:w:0xe2:m`
+
+ATiny 841 - To preserve eeprom when reflashing the image.
+`./avrdude -c usbtiny -p t841 -U hfuse:w:0xd6:m`
 
 # Hacking and Contributing
 
@@ -19,8 +23,9 @@ ATTiny 841 - 8Mhz internal `avrdude -c usbtiny -p t841 -U lfuse:w:0xe2:m`
 
 ## Operation
 * Use up/down buttons as per factory module (long press/hold)
-* To store in a memory slot, push the up button a certain number of times, but long-hold the last press until you hear some beeps corresponding to the memory position that has been saved.
-* To recall a saved position N, push the up button N times.
+* To store in a memory slot, push the up/down button a certain number of times, but long-hold the last press until you hear some beeps corresponding to the memory position that has been saved.
+* To recall a saved position N, push the up/down button N times. Where N >= 2.
+* Up and down buttons have separate memory settings
 
 ## pio
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Any unit shipped after Feb 20, 2021 from the Tindie store will have the 3rd mode
 
 # Setting and Recalling memory slots
 
+Note. Recent software allows either button to store and recall memory.
+
 ## Setting
 To set assign a memory slot you press the up button two or more times. On the final button press you hold until you hear a tone that indicates what slot you have assigned (2 beeps, 3 beeps, etc).
 


### PR DESCRIPTION
- Added both-buttons save and recall functionality. controlled with \#define BOTHBUTTONS
- Any button press during memory move will immediately stop the desk.
- Logic to ensure multi-press is reset if the button changes. 
>    eg: up, up, down, down 
>      is treated as down, down. 
>      not down, down, down, down

- Made beep and playTone() leaner still and improved pitch adjustment.
- beep() has default count=1
- Explicitly set reference time at start of linBurst().
- Some additional (small) memory savings 
- Conformed better to the naming convention.

Image stats - with serial + minmax + both-buttons all enabled:
RAM:   [====      ]  38.9% (used 199 bytes from 512 bytes)
Flash: [========= ]  86.6% (used 7096 bytes from 8192 bytes)