### PR TITLE
Serial rework with human-readable option and Tone command

### DIFF
--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -39,9 +39,8 @@ void linInit();
 void linBurst();
 
 void recvWithStartEndMarkers();
-void writeSerial(char operation, uint16_t position, uint8_t push_addr = 0);
-int BitShiftCombine(uint8_t x_high, uint8_t x_low);
-void parseData();
+void writeSerial(byte operation, uint16_t position, uint8_t push_addr = 0);
+void parseData(byte command, uint16_t position, uint8_t push_addr);
 
 void delayUntil(unsigned long microSeconds);
 

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -146,6 +146,7 @@ const char command_write = 'W';
 const char command_load = 'L';
 const char command_current = 'C';
 const char command_read = 'R';
+const char command_tone = 'T';
 #endif
 
 // set/clear motor up command
@@ -396,17 +397,20 @@ void parseData(byte command, uint16_t position, uint8_t push_addr)
     -    decrease
     =    absolute
     C    Ask for current location
-    W    Write EEPROM
+    W    Write EEPROM location
     R    Read EEPROM location
     L    Load EEPROM location
+    T    play tone
 
   position (third/fourth bytes)
-    +-   relitave to current
+    +-   relative to current
     =W   absolute
+    T    tone frequency
     CRL  (ignore)
 
   push_addr (fifth byte)
     WRL   EEPROM pushCount number
+    T     tone duration/4 ms. (250 == 1s)
     *     (ignore)
   */
 
@@ -460,6 +464,10 @@ void parseData(byte command, uint16_t position, uint8_t push_addr)
   else if (command == command_read)
   {
     writeSerial(command_read, eepromGet16(push_addr), push_addr);
+  }
+  else if (command == command_tone)
+  {
+    playTone(position, push_addr*4); // 256*4 ~ 1048ms max
   }
 }
 #endif

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -97,7 +97,7 @@
 #define BOTHBUTTON_SLOT  18 // store whether bothbuttons is enabled
 #define DOWN_SLOT_START  32 // 0x20 in hex offset for down button slots
 
-// any button pressed
+// any button pressed?
 #define PRESSED(b) (b != Button::NONE)
 // is a memory button?
 #define MEMORY_BUTTON(b) ((b == Button::UP) || ( bothbuttons && (b == Button::DOWN)))
@@ -181,8 +181,7 @@ void setup()
   if (!digitalRead(PIN_DOWN))
   {
     initAndReadEEPROM(true);
-    beep(NOTE_C7);
-    beep(NOTE_C7);
+    beep(NOTE_C7, 2);
     delay(LONG_PAUSE);
     while (true)
     {


### PR DESCRIPTION
Added Tone command to play tones over serial.

Added #define option for human-readable serial output. Note that this almost maxes out the available flash.

Reworked serial so that commands can be viewed/controlled char-by-char by humans. try these example commands: 
<T2000,255  <=3000,. <C0.0.  <+200,0.  <L.2. <C.. <R,0 <R.34

Avoid processing anything if currentHeight =0. This situation uncovered with serial monitoring. outputs:
 <=x,0 <-x,0 <=0,0, <+x,0 <=x,0 at the end of memory-moves.

Various memory savings.

Avoid bad targetHeight values which can happen if bad data is read from eeprom.

Without serial:
RAM:   [====      ]  41.6% (used 213 bytes from 512 bytes)
Flash: [========  ]  84.5% (used 6924 bytes from 8192 bytes)

with regular serial:
RAM:   [======    ]  55.1% (used 282 bytes from 512 bytes)
Flash: [========= ]  93.3% (used 7640 bytes from 8192 bytes)

with human-readable serial:
RAM:   [======    ]  56.1% (used 287 bytes from 512 bytes)
Flash: [==========]  98.4% (used 8062 bytes from 8192 bytes)