### PR TITLE
Extra optional debug. and move reset slot to 15

### DIFF
--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -55,6 +55,7 @@ const char command_tone      = 'T';
 const char txMarker          = '>'; // default start marker from desk (Tx)
 const char lateMarker        = '!'; // when reporting delayUntil was late
 const char bootfailMarker    = '*'; // when linInit fails to communicate
+const char response_idle     = 'i'; // indicates the type of idle packet
 const char response_error    = 'E'; // indicates an error
 const char response_calibration = 'X'; // indicates calibration is starting
 
@@ -64,7 +65,7 @@ void beep(uint16_t freq, byte count=1);
 void delayUntil(uint16_t milliSeconds);
 
 void linInit();
-void linBurst();
+uint8_t linBurst();
 
 void sendInitPacket(byte a1 = 255, byte a2 = 255, byte a3 = 255, byte a4 = 255);
 byte recvInitPacket(byte array[]);

--- a/Code/platformio.ini
+++ b/Code/platformio.ini
@@ -20,12 +20,12 @@ framework = arduino
 ;monitor_speed = 19200
 monitor_speed = 115200
 ; hexbyte display
-monitor_filters = hexlify
-monitor_flags = --encoding
-    Latin1 ; required for hexlify filter to display *all* values in hex
+;monitor_filters = hexlify
+;monitor_flags = --encoding
+;    Latin1 ; required for hexlify filter to display *all* values in hex
 
 ; human serial settings
-;monitor_filters = direct
+monitor_filters = direct
 ;, time, log2file ; for timestamps and logging
 board_fuses.lfuse = 0xE2
 board_fuses.efuse = 0xFE

--- a/Code/src/lin.cpp
+++ b/Code/src/lin.cpp
@@ -139,7 +139,7 @@ uint8_t Lin::recv(uint8_t addr, uint8_t* message, uint8_t nBytes)
   }
   readByte = read_withtimeout(countDown);
   bytesRcvd++;
-  if (dataChecksum(message,nBytes,idByte) == readByte) bytesRcvd = 0xff;
+  if (dataChecksum(message,nBytes,(addr == 0x3d) ? 0: idByte) != readByte) bytesRcvd = 0xff;
 
 done:
   serial.flush();

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -778,7 +778,7 @@ uint8_t linBurst()
   // Recv from PID 09
 #ifdef DEBUG_ENCODER
   uint8_t chars = lin.recv(9, node_b, 3);
-  if (chars != 4) // && (chars <0xF0))
+  if (chars != 4)
     writeSerial(node_b[1], (node_b[0]<<8) + node_b[2], 1, chars);
 #else
   lin.recv(9, node_b, 3);
@@ -788,7 +788,7 @@ uint8_t linBurst()
   // Recv from PID 08
 #ifdef DEBUG_ENCODER
   chars = lin.recv(8, node_a, 3);
-  if (chars != 4) // && (chars <0xF0))
+  if (chars != 4)
     writeSerial(node_a[1], (node_a[0]<<8) + node_a[2], 0, chars);
 #else
   lin.recv(8, node_a, 3);
@@ -811,7 +811,7 @@ uint8_t linBurst()
   currentHeight = enc_a;
 #ifdef DEBUG_ENCODER
   if (((enc_a>enc_b) && (enc_a-enc_b>20)) ||
-      ((enc_b>enc_a) && (enc_b-enc_a>20 )))
+      ((enc_b>enc_a) && (enc_b-enc_a>20)))
     writeSerial(node_a[1], (node_a[0]<<8) + node_b[1], node_b[0], 0xAA);
 #endif
 

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -19,9 +19,14 @@
 // Report errors over serial
 #define SERIALERRORS
 
-// raw debug of packets sent during init over serial.
-// turn off HUMANSERIAL,SERIALECHO & use hexlify
+// Report the variant (idle) type on move
+//#define SERIAL_IDLE
+
+// raw data. turn off HUMANSERIAL,SERIALECHO & use hexlify..
+// Debug of packets sent during init over serial.
 //#define DEBUGSTARTUP
+// Debug of encoder values in linBurst.
+//#define DEBUG_ENCODER
 
 // easter egg
 #define EASTER
@@ -37,12 +42,12 @@
 #define EEPROM_SIG_SLOT  0
 #define MAGIC_SIG    0x120d // bytes: 13, 18 in little endian order
 #define MIN_SLOT         2  // 1 is possible but cant save without serial
-#ifdef ENABLERESET
-#define FORCE_RESET      5  // force reset - once tested move to 10?
-#endif
 #define MIN_HEIGHT_SLOT  11
 #define MAX_HEIGHT_SLOT  12
 #define RECALIBRATE      14 // nothing is stored there
+#ifdef ENABLERESET
+#define FORCE_RESET      15  // force reset
+#endif
 #define RESERVED_VARIANT 16 // reserved - deliberately empty
 #define FEEDBACK_SLOT    17 // short tones on every button-press. buzz on no-ops
 #define BOTHBUTTON_SLOT  18 // store whether bothbuttons is enabled
@@ -641,7 +646,7 @@ void loop()
 
   // Wait before next cycle. 150ms on factory controller, 25ms seems fine.
   delayUntil(25);
-  linBurst();
+  uint8_t drift = linBurst(); // drift is difference between enc_a and enc_b
 
   // If we are in recalibrate mode or have a bad currentHeight, don't act on input.
   if (state >= State::STARTING_RECAL || currentHeight <= 5)
@@ -658,10 +663,9 @@ void loop()
     else {
       writeSerial(command_decrease, oldHeight-currentHeight);
     }
-    writeSerial(command_absolute, currentHeight);
+    writeSerial(command_absolute, currentHeight, drift);
     oldHeight = currentHeight;
   }
-
   recvData();
 #endif
 
@@ -759,7 +763,7 @@ void loop()
 
 }
 
-void linBurst()
+uint8_t linBurst()
 {
   static byte empty[3] = {0, 0, 0};
   static byte cmd[3] = {0, 0, 0};
@@ -772,11 +776,23 @@ void linBurst()
 
   delayUntil(5);
   // Recv from PID 09
+#ifdef DEBUG_ENCODER
+  uint8_t chars = lin.recv(9, node_b, 3);
+  if (chars != 4) // && (chars <0xF0))
+    writeSerial(node_b[1], (node_b[0]<<8) + node_b[2], 1, chars);
+#else
   lin.recv(9, node_b, 3);
+#endif
 
   delayUntil(5);
   // Recv from PID 08
+#ifdef DEBUG_ENCODER
+  chars = lin.recv(8, node_a, 3);
+  if (chars != 4) // && (chars <0xF0))
+    writeSerial(node_a[1], (node_a[0]<<8) + node_a[2], 0, chars);
+#else
   lin.recv(8, node_a, 3);
+#endif
 
   // Send PID 16, 6 times
   for (byte i = 0; i < 6; i++)
@@ -793,6 +809,11 @@ void linBurst()
   uint16_t enc_b = node_b[0] | (node_b[1] << 8);
   uint16_t enc_target = enc_a;
   currentHeight = enc_a;
+#ifdef DEBUG_ENCODER
+  if (((enc_a>enc_b) && (enc_a-enc_b>20)) ||
+      ((enc_b>enc_a) && (enc_b-enc_a>20 )))
+    writeSerial(node_a[1], (node_a[0]<<8) + node_b[1], node_b[0], 0xAA);
+#endif
 
   // Send PID 18
   switch (state)
@@ -861,6 +882,9 @@ void linBurst()
         if (node_a[2] == LIN_MOTOR_IDLE1 || node_a[2] == LIN_MOTOR_IDLE2 || node_a[2] == LIN_MOTOR_IDLE3)
         {
           state = State::STARTING;
+#if (defined SERIALCOMMS && defined SERIAL_IDLE)
+          writeSerial(response_idle, 0, node_a[2]); // Indicate the idle variant type
+#endif
         }
       }
     }
@@ -925,6 +949,7 @@ void linBurst()
     state = State::OFF;
     break;
   }
+  return ((enc_b>enc_a)?enc_b-enc_a:enc_a-enc_b);
 }
 
 // lean EEPROM functions to get/put 16bit values

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Memory position 14.
 
 The factory recalibration routine has been implemented. The original BEKANT controller is no longer needed to recalibrate motors. **This will cause the desk to move to the lowest possible extremity. Please exercise caution and be prepared to unplug the power if needed.** Any interruption to this procedure requires a power-cycle.
 
+### Reset
+Memory position 15.
+
+Reboot megadesk controller without power-cycling. On success, plays a full fanfare. On failure, repeatedly plays partial fanfare until communications succeed with both legs/motors.
+
+
 ### Serial control 
 Disabled by default in codebase/firmwares.
 
@@ -78,6 +84,7 @@ Any unit shipped after Feb 20, 2021 from the Tindie store will have the 3rd mode
 | 11        | Set the lowest/minimum height to current position, or, reset back to default (toggles) | Single low beep
 | 12        | Set the highest/maximum height to current position, or, reset back to default (toggles) | Single low beep
 | 14        | Recalibration procedure, desk will lower down to the lowest limits | (Will begin moving)
+| 15        | Reset | Fanfare
 | 16        | Units before Feb 2021 - toggle different variants. Newer units, no operation
 | 18        | Toggle audio-feedback mode
 | 18        | Toggle both-button mode


### PR DESCRIPTION
Extra telemetry to debug how the desk gets to the point it needs recalibration.
Report drift between encoders of two legs.
Fix Lin checksum validation.

RAM:   [========  ]  77.9% (used 399 bytes from 512 bytes)
Flash: [========= ]  90.6% (used 7426 bytes from 8192 bytes)
