### PR TITLE
More accurate position seeks. Fix for #77

### DIFF
--- a/Code/include/megadesk.h
+++ b/Code/include/megadesk.h
@@ -51,16 +51,28 @@ const char command_write     = 'W';
 const char command_read      = 'R';
 const char command_current   = 'C'; // report current height
 const char command_tone      = 'T';
+
 // responses only..
 const char txMarker          = '>'; // default start marker from desk (Tx)
+const char response_error    = 'E'; // indicates an error
+const char response_calibration = 'X'; // indicates calibration is starting
+
+// error markers
 const char lateMarker        = '!'; // when reporting delayUntil was late
 const char bootfailMarker    = '*'; // when linInit fails to communicate
 const char badPID8Marker     = '8'; // when pid8 fails to respond
 const char badPID9Marker     = '9'; // when pid9 fails to respond
 const char DriftMarker       = 'D'; // when pid8 and pid9 report different positions
-const char response_idle     = 'i'; // indicates the type of idle packet
-const char response_error    = 'E'; // indicates an error
-const char response_calibration = 'X'; // indicates calibration is starting
+
+// idle markers
+const char idleMarker        = 'i'; // indicates the type of idle packet
+const char response_stop     = 's'; // during stop idle
+const char response_off      = 'o'; // when starting from off-state
+
+// debugheight markers
+const char response_up       = '^'; // raising to targetheight
+const char response_down     = 'v'; // lowering to targetheight
+const char response_halt     = '~'; // halt moving! aim for targetheight
 
 void playTone(uint16_t freq, uint16_t duration);
 void beep(uint16_t freq, byte count=1);

--- a/Code/src/lin.cpp
+++ b/Code/src/lin.cpp
@@ -105,11 +105,11 @@ int Lin::read_withtimeout(int16_t &countDown)
   return serial.read();
 }
 
-// returns character read or:
+// returns number of characters read (including checksum) or:
 // returns 0xfd if serial isn't echoing
 // returns 0xfe if serial echoed only the sync - a fluke?
 // returns 0xff for checksum error
-// returns 0 if no characters.
+// returns 0 if no response.
 uint8_t Lin::recv(uint8_t addr, uint8_t* message, uint8_t nBytes)
 {
   uint8_t bytesRcvd=0;

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -935,8 +935,6 @@ uint8_t linBurst()
     else
       enc_target = enc_max;
     lin_cmd = LIN_CMD_FINISH;
-    //if (isIdle(node_a[2]) && isIdle(node_b[2]))
-    //if ((node_a[2] == node_b[2]) && isIdle(node_a[2]))
     // only check one, as that's good enough...
     if (isIdle(node_a[2]))
     {
@@ -969,9 +967,6 @@ uint8_t linBurst()
     targetHeight = enc_max; // prevents immediately resuming previous height
     break;
 
-  // default: // unused
-  //   state = State::OFF;
-  //   break;
   }
 
   // lastly send lin command to PID 18

--- a/Code/src/megadesk.cpp
+++ b/Code/src/megadesk.cpp
@@ -779,6 +779,11 @@ void loop()
 
 }
 
+// check if motor is idle
+bool isIdle(byte value) {
+  return (value == LIN_MOTOR_IDLE1 || value == LIN_MOTOR_IDLE2 || value == LIN_MOTOR_IDLE3);
+}
+
 uint8_t linBurst()
 {
   static byte empty[3] = {0, 0, 0};
@@ -860,8 +865,7 @@ uint8_t linBurst()
   case State::OFF:
     if (user_cmd != Command::NONE)
     {
-      if ((node_a[2] == node_b[2]) &&
-          (node_a[2] == LIN_MOTOR_IDLE1 || node_a[2] == LIN_MOTOR_IDLE2 || node_a[2] == LIN_MOTOR_IDLE3))
+      if (isIdle(node_a[2]) && isIdle(node_b[2]))
       {
         state = State::STARTING;
       }
@@ -923,8 +927,7 @@ uint8_t linBurst()
     else
       enc_target = enc_max;
     lin_cmd = LIN_CMD_FINISH;
-    if ((node_a[2] == node_b[2]) &&
-        (node_a[2] == LIN_MOTOR_IDLE1 || node_a[2] == LIN_MOTOR_IDLE2 || node_a[2] == LIN_MOTOR_IDLE3))
+    if (isIdle(node_a[2]))
     {
       state = State::OFF;
     }


### PR DESCRIPTION
- Added DEBUGHEIGHT #def for detailed position/targetheight telemetry.
- More detailed SERIAL_IDLE telemetry - catches the manual-button-down not-working issue: mismatched idle values.
- Relaxed motor LIN_MOTOR_IDLE checks, motor A doesn't have to match motor B idle value, so long as both are idle. Fix for #77 
- Adjusted interval between linBurst() calls from 25ms to 50ms. Comment says original controller use 150ms, 50ms seems safer?, and appears to result in better accuracy...
- Changed lots of lin command encoder values to use either the min() or max() of the values just read - image size savings.
- Consolidated linBurst() switch statements to one for image size savings.
- Avoid clearing/resetting targetHeight, greater accuracy means it's no longer necessary. exception: after recalibration.
- memoryMoving variable is more accurate, now not cleared until motors are idle.
- Made serial telemetry more terse. Don't report over serial until movement is complete (except when using manual up/down).
- Use targetHeight during final stopping states to home-in on requested position. Improved accuracy - usually within 10 of the requested height:
```
>l1500,2  # request 1500 via button press
>-810,0
>=1491,3  # arrived at 1491

<=3200,0  # raise to 3200 via serial
>+1704,0
>=3195,3  # arrived at 3195

<=1500,0  # descend to 1500 via serial
>-1692,0
>=1503,6

<-350,0   # request down 350 via serial
>-345,0   # moved 345
>=5052,9

<+800,0   # request up 800 via serial
>+789,0   # moved 789
>=2292,0
```

Code-size comparison with #define SERIALCOMMS, HUMANSERIAL, SERIALECHO, SERIALERRORS
```
previously:
RAM:   [========  ]  77.5% (used 397 bytes from 512 bytes)
Flash: [========= ]  91.9% (used 7528 bytes from 8192 bytes)
now:
RAM:   [========  ]  76.4% (used 391 bytes from 512 bytes)
Flash: [========= ]  90.0% (used 7376 bytes from 8192 bytes)
```