### PR TITLE
Update esphome.md

### DIFF
--- a/esphome.md
+++ b/esphome.md
@@ -123,7 +123,7 @@ esphome:
       - uart.write: "<R0.12."
 
 logger:
-  baud_rate:0
+  baud_rate: 0
 
 api:
   password: ""


### PR DESCRIPTION
fixed missing space after baud_rate. copy/paste caused configuration to error out with "expected a dictionary"