### PR TITLE
Update megadesk-companion.yaml

### DIFF
--- a/esphome/megadesk-companion.yaml
+++ b/esphome/megadesk-companion.yaml
@@ -2,6 +2,8 @@ esp32:
   board: esp32-c3-devkitm-1
   framework:
     type: arduino
+    version: 2.0.9
+    platform_version: https://github.com/platformio/platform-espressif32.git#v5.3.0
 
 esphome:
   name: megadesk


### PR DESCRIPTION
esp32-c3 support has been added only last year to arduino/espressif32. Doesn't seem to run with older versions. Added the most recent versions to the yaml to make avoid running into version issues/conflicts.